### PR TITLE
typo fix in add-main-to-aot

### DIFF
--- a/src/leiningen/ring/jar.clj
+++ b/src/leiningen/ring/jar.clj
@@ -27,7 +27,7 @@
              (~(generate-resolve 'ring.server.leiningen/serve) '~options))))))
 
 (defn add-main-to-aot [aot-list main-ns]
-  (if (= aot-list [:all])
+  (if (= aot-list :all)
     aot-list
     (-> aot-list (conj main-ns) distinct)))
 


### PR DESCRIPTION
The value of `:aot` key is either a vector of namespaces or the `:all` keyword. Fixed a typo where function checks for `[:all]` instead of `:all`.